### PR TITLE
Fix Rubric logic so that object specific rubrics are handled correctly.

### DIFF
--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -34,6 +34,7 @@ class RubricsController < ApplicationController
     if params[:task_id]
       # Creating a new rubric for a Task.
       @rubric.level = :task
+      @rubric.rubricable = Task.find(params[:task_id])
       # Use the Stands set by the Task.
       @strands = Task.find(params[:task_id]).strands
       # Check for existing rubrics for this objective and pick the ones that
@@ -61,6 +62,7 @@ class RubricsController < ApplicationController
   # POST /rubrics
   # POST /rubrics.json
   def create
+    binding.pry
     @rubric = Rubric.new(rubric_params)
     authorize @rubric
 
@@ -73,6 +75,7 @@ class RubricsController < ApplicationController
         format.json { render json: @rubric.errors, status: :unprocessable_entity }
       end
     end
+    binding.pry
   end
 
   # PATCH/PUT /rubrics/1
@@ -110,6 +113,7 @@ class RubricsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def rubric_params
-    params.require(:rubric).permit(:level, :band, :criterion, :strand_id, :base_rubric_id)
+    params.require(:rubric).permit(:level, :band, :criterion, :strand_id,
+                                   :rubricable, :base_rubric_id)
   end
 end

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -31,15 +31,13 @@ class RubricsController < ApplicationController
     authorize @rubric
     store_location
 
+    # XXX - need to set contexts for a Unit or Project rubric as well, others?
     if params[:task_id]
       # Creating a new rubric for a Task.
       @rubric.level = :task
       @rubric.rubricable = Task.find(params[:task_id])
       # Use the Stands set by the Task.
       @strands = Task.find(params[:task_id]).strands
-      # Check for existing rubrics for this objective and pick the ones that
-      # are the closest fit (others at the Task level, otherwise the closest
-      # ones above).
     end
     if params[:base_rubric_id]
       # Creating a new rubric based on a, presumably, "higher" level one.

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -51,7 +51,6 @@ class RubricsController < ApplicationController
       @rubric.band = @base_rubric.band
       @rubric.criterion = @base_rubric.criterion
     end
-    binding.pry
   end
 
   # GET /rubrics/1/edit
@@ -66,7 +65,6 @@ class RubricsController < ApplicationController
     @rubric = Rubric.new(rubric_params)
     authorize @rubric
     @rubric.verify_level
-    binding.pry
 
     respond_to do |format|
       if @rubric.save
@@ -84,7 +82,6 @@ class RubricsController < ApplicationController
   def update
     authorize @rubric
     @rubric.verify_level
-    binding.pry
     respond_to do |format|
       if @rubric.update(rubric_params)
         format.html { redirect_back_or_default notice: 'Rubric was successfully updated.' }

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -51,6 +51,7 @@ class RubricsController < ApplicationController
       @rubric.band = @base_rubric.band
       @rubric.criterion = @base_rubric.criterion
     end
+    binding.pry
   end
 
   # GET /rubrics/1/edit
@@ -62,9 +63,10 @@ class RubricsController < ApplicationController
   # POST /rubrics
   # POST /rubrics.json
   def create
-    binding.pry
     @rubric = Rubric.new(rubric_params)
     authorize @rubric
+    @rubric.verify_level
+    binding.pry
 
     respond_to do |format|
       if @rubric.save
@@ -75,13 +77,14 @@ class RubricsController < ApplicationController
         format.json { render json: @rubric.errors, status: :unprocessable_entity }
       end
     end
-    binding.pry
   end
 
   # PATCH/PUT /rubrics/1
   # PATCH/PUT /rubrics/1.json
   def update
     authorize @rubric
+    @rubric.verify_level
+    binding.pry
     respond_to do |format|
       if @rubric.update(rubric_params)
         format.html { redirect_back_or_default notice: 'Rubric was successfully updated.' }
@@ -114,6 +117,6 @@ class RubricsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def rubric_params
     params.require(:rubric).permit(:level, :band, :criterion, :strand_id,
-                                   :rubricable, :base_rubric_id)
+                                   :rubricable_id, :rubricable_type, :base_rubric_id)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,7 +31,11 @@ class TasksController < ApplicationController
     strand_ids = @strands.map(&:id)
     # Find applicable Rubrics
     @rubrics = []
-    rubric_candidates = Rubric.where(strand_id: strand_ids)
+    rubric_candidates = Rubric
+                        .where(
+                          strand_id: strand_ids,
+                          rubricable: [[@task], nil]
+                        )
     strand_ids.each do |sid|
       strand_rubrics = rubric_candidates.select { |r| r.strand_id == sid }
       bands = strand_rubrics.map &:band

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -29,7 +29,7 @@ class Assessment < ActiveRecord::Base
     strand_ids.each do |sid|
       strand_rubrics = candidates.select { |r| r.strand_id == sid }
       bands = strand_rubrics.map &:band
-      bands.each do |band|
+      bands.uniq.each do |band|
         band_max = strand_rubrics.select { |r| r.band == band }.max_by &:level
         rubrics += [band_max]
       end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -25,9 +25,13 @@ class Assessment < ActiveRecord::Base
   def rubric
     strand_ids = strands.map &:id
     rubrics = []
-    candidates = Rubric.where(strand_id: strand_ids)
+    rubric_candidates = Rubric
+                        .where(
+                          strand_id: strand_ids,
+                          rubricable: [[@task], nil]
+                        )
     strand_ids.each do |sid|
-      strand_rubrics = candidates.select { |r| r.strand_id == sid }
+      strand_rubrics = rubric_candidates.select { |r| r.strand_id == sid }
       bands = strand_rubrics.map &:band
       bands.uniq.each do |band|
         band_max = strand_rubrics.select { |r| r.band == band }.max_by &:level

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -58,7 +58,6 @@ class Assessment < ActiveRecord::Base
   # TODO: default autoscore methods (return 0 if body is empty & no images).
   #
   def scoreable(autoscore = false)
-    # binding.pry
     Post.where(assessment: id)
   end
 

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -5,7 +5,16 @@ class Rubric < ActiveRecord::Base
   validates :band, presence: true
   validates :criterion, presence: true
   validates :level, presence: true
-  validates :task_id, value: nil
+  validates :task_id, value: nil # Should be unused.
 
   enum level: %i( authority school subject unit project task )
+
+  def verify_level
+    # If a Rubric is created in the context of a :level (e.g., a Task),
+    # :rubricable will be set to the object. If the user changes :level in the
+    # course of the edit, set rubricable to nil.
+    unless level.casecmp(rubricable_type) == 0
+      self.rubricable = nil
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,4 +17,8 @@ class Task < ActiveRecord::Base
   has_many :rubrics, as: :rubricable
 
   has_many :scores, through: :assessments
+
+  def to_s
+    title
+  end
 end

--- a/app/views/rubrics/_form.html.erb
+++ b/app/views/rubrics/_form.html.erb
@@ -2,13 +2,15 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+    <%= f.association :strand,
+                      include_blank: '--- Select Objective Strand ---' %>
+
     <%= f.input :level, as: :radio_buttons,
                 item_wrapper_class: :inline,
                 collection: Rubric.levels.keys,
                 selected: :corroborated %>
 
-    <%= f.association :strand,
-                      include_blank: '--- Select Objective Strand ---' %>
+    <%= f.input :rubricable, collection: Task.all %>
 
     <%# TODO: set bands dynamically %>
     <%= f.input :band, as: :radio_buttons,

--- a/app/views/rubrics/_form.html.erb
+++ b/app/views/rubrics/_form.html.erb
@@ -1,5 +1,4 @@
 <%= simple_form_for(@rubric) do |f| %>
-  <% binding.pry %>
   <%= f.error_notification %>
 
   <div class="form-inputs">
@@ -16,10 +15,13 @@
                 collection: [ '0', '1-2', '3-4', '5-6', '7-8' ]%>
 
     <%= f.input :criterion, input_html: {rows: 8} %>
-    <%= f.hidden_field :rubricable %>
+    <%= f.hidden_field :rubricable_id %>
+    <%= f.hidden_field :rubricable_type %>
+
   </div>
 
   <div class="form-actions">
     <%= f.button :submit %>
   </div>
+
 <% end %>

--- a/app/views/rubrics/_form.html.erb
+++ b/app/views/rubrics/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for(@rubric) do |f| %>
+  <% binding.pry %>
   <%= f.error_notification %>
 
   <div class="form-inputs">
@@ -15,6 +16,7 @@
                 collection: [ '0', '1-2', '3-4', '5-6', '7-8' ]%>
 
     <%= f.input :criterion, input_html: {rows: 8} %>
+    <%= f.hidden_field :rubricable %>
   </div>
 
   <div class="form-actions">

--- a/app/views/rubrics/_index.html.erb
+++ b/app/views/rubrics/_index.html.erb
@@ -47,7 +47,7 @@ grid(@rubrics_grid) do |g|
   if policy(Rubric).create?
     g.column do |t|
       # To create a new rubric item using this one as the defaults
-      link_to 'Clone', new_rubric_path(:base_rubric_id => t.id)
+      link_to 'Clone', new_rubric_path(base_rubric_id: t.id, task_id: @task)
     end
   end
   unless params[:controller] == 'posts'

--- a/app/views/rubrics/_index.html.erb
+++ b/app/views/rubrics/_index.html.erb
@@ -16,21 +16,19 @@ grid(@rubrics_grid) do |g|
       last_strand = t.strand.to_s(:short)
       content_tag(:tr,
         content_tag(:td,
-                    t.strand.to_s(:full),
+                    (markdown t.strand.to_s(:full)),
                     colspan: number_of_columns
         )
       )
     end
   end
 
-  # if current_user.teacher? || current_user.admin?
-  if false == true
+  if current_user.teacher? || current_user.admin?
     g.column name: 'Level' do |t|
       t.level
     end
-
-    g.column name: 'Strand' do |t|
-      t.strand.to_s(:short)
+    g.column name: 'Rubricable' do |t|
+      t.rubricable
     end
   end
   g.column do |t|

--- a/app/views/tasks/_task_instructions.html.erb
+++ b/app/views/tasks/_task_instructions.html.erb
@@ -7,7 +7,6 @@
 
 <% if task %>
   <p>
-    <%# binding.pry %>
     <%= if task then markdown Task.find(task).body end %>
   </p>
   <%= if policy(task).edit? then link_to 'Edit', edit_task_path(task) end %>

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -22,4 +22,29 @@ RSpec.describe Rubric, type: :model do
       expect(rubric).to be_valid
     end
   end
+
+  describe 'verify_level' do
+    it 'sets rubricable to nil if level does not match rubricable' do
+      task = Task.create
+      rubric = Fabricate.build(:rubric,
+                               level: :unit,
+                               rubricable: task
+                              #  rubricable_type: Task,
+                              #  rubricable_id: 1
+                              )
+      rubric.verify_level
+      expect(rubric.rubricable).to be_nil
+    end
+    it 'preserves rubricable when level matches rubricable' do
+      task = Task.create
+      rubric = Fabricate.build(:rubric,
+                               level: :task,
+                               rubricable: task
+                              #  rubricable_type: Task,
+                              #  rubricable_id: 1
+                              )
+      rubric.verify_level
+      expect(rubric.rubricable).not_to be_nil # XXX - should equal task
+    end
+  end
 end


### PR DESCRIPTION
This commit handles setting rubricable. It should be set whenever a
rubric is created in the context of a Task (and needs to be extended
to also work for Units and Projects -- at least). But it should be
cleared if level is not left set to match the context. You do not
have to create a Rubric for that context.