### PR TITLE
Another performance improvement.

### DIFF
--- a/app/helpers/home_teacher_helper.rb
+++ b/app/helpers/home_teacher_helper.rb
@@ -101,7 +101,7 @@ module HomeTeacherHelper
   end
 
   def posts_for_assessment(aid, posts)
-    post_or_posts = posts.where(assessment: aid)
+    post_or_posts = posts.find_all { |p| p.assessment == aid }
     case post_or_posts.count
     when 0
       [{ pid: nil, title: nil, status: nil }]


### PR DESCRIPTION
find_all (aka select) is faster than where in this case because it
doesn’t make a DB query, instead getting the posts from the array,
which is already loaded or only will be loaded once.